### PR TITLE
Feature/publish on GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ composer.lock
 .project
 .settings/
 .DS_Store
-/vendor
+vendor/
+build/
+node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing
+
+We love pull requests from everyone! Here are some basic tips and tricks for constructive contribution.
+
+## Prerequisites
+
+* npm (https://www.npmjs.org) (e.g. `brew install node`)
+* Composer (https://getcomposer.org) (e.g. `brew install composer`)
+* Ability to switch versions of PHP CLI for unit testing purposes (e.g. `brew uninstall php70 & brew install php55`)
+
+## Fork, Clone and Install
+
+Fork, then clone the repo and cd into the project root:
+
+    git clone git@github.com:your-username/jira-issue-collector.git
+    cd jira-issue-collector
+
+We suggest you always use [Composer](https://getcomposer.org/) `update` in the project (as opposed to `install`):
+
+    composer update
+    
+Note: Since this is a library, we `.gitignore` the `composer.lock`, as the lock file is the domain of the consuming
+application, not the library.
+
+## Unit Tests and Coding Style Tests
+
+The project is setup to run all the tests via [grunt](http://gruntjs.com/getting-started). (See
+`package.json` and `Gruntfile.js` in the project root.)
+
+Before you start, make sure that you have Node installed on your system, and install the required packages:
+
+    npm install
+
+Make sure the tests run using grunt:
+
+    grunt
+
+The default grunt task is aliased to test, so it is the same as running test explicitly:
+
+    grunt test
+
+The Gruntfile is setup to generate clover XML coverage reports for use in the CI environment like this:
+
+    grunt test:ci
+
+Alternatively, you can run the tests directly like this:
+
+    php ./vendor/bin/phpunit -c phpunit.xml.dist
+    php ./vendor/bin/phpcs -p --standard=PSR2 src/ tests/ config/
+
+## Branch, Change and Test
+
+Before you make your changes, please create a new branch. Example:
+
+    git checkout -b feature/my-thing
+
+Make your change. Add tests for your change. Make sure the tests pass (or run manually as above):
+
+    grunt
+
+## Create Pull Request
+
+Push your new branch to your fork and [submit a pull request][pr].
+
+[pr]: https://github.com/soliantconsulting/jira-issue-collector/compare/
+
+At this point you're waiting on us. We try to at least comment on pull requests within three business days (and,
+typically, one business day). If you don't get any response within three days, feel free to bump it with a comment. We
+may suggest some changes or improvements or alternatives.
+
+## Tips
+
+Some things that will increase the chance that your pull request is accepted:
+
+* Don't break existing tests.
+* Write test coverage for your change(s).
+* Follow the PSR-2 [coding standards][style].
+* Write [good commit messages][commit].
+* Explain and/or justify the reason for the change in your PR description.
+
+[style]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
+[commit]: https://git-scm.com/book/ch5-2.html#Commit-Guidelines

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,74 @@
+module.exports = function(grunt) {
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        phplint: {
+            all: [
+                'config/**/*.php{,.dist}',
+                'src/**/*.{php,phtml}',
+                'tests/**/*.{php,phtml}'
+            ]
+        },
+        phpcs: {
+            all: {
+                src: [
+                    'config/',
+                    'src/',
+                    'tests/'
+                ]
+            },
+            options: {
+                // hack: args not directly supported by grunt-phpcs can be added in the bin path
+                bin: 'vendor/bin/phpcs -p --extensions=dist,php,phtml',
+                standard: 'PSR2',
+                encoding: 'utf-8',
+                verbose: false
+            }
+        },
+        phpunit: {
+            Module: {
+                configuration: 'phpunit.xml.dist'
+            },
+            options: {
+                bin: 'vendor/bin/phpunit'
+            }
+        },
+        mkdir: {
+            build: {
+                options: {
+                    create: [
+                        'build/logs'
+                    ]
+                }
+            }
+        }
+    });
+
+    // Plugin loading
+    grunt.loadNpmTasks('grunt-mkdir');
+    grunt.loadNpmTasks('grunt-phpcs');
+    grunt.loadNpmTasks("grunt-phplint");
+    grunt.loadNpmTasks('grunt-phpunit');
+
+    // Task registration
+    grunt.registerTask('default', ['test']);
+    grunt.registerTask('test', function (env) {
+        if (env === 'ci') {
+            // In CI, we want to collect coverage reports
+            grunt.task.run(['mkdir:build']);
+
+            var phpunitConfig = grunt.config.get('phpunit');
+
+            for (var property in phpunitConfig) {
+                if (property === 'options') {
+                    continue;
+                }
+
+                phpunitConfig[property].coverageClover = 'build/logs/clover-' + property + '.xml';
+            }
+
+            grunt.config.set('phpunit', phpunitConfig)
+        }
+
+        grunt.task.run(['phplint', 'phpcs', 'phpunit']);
+    });
+};

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
  
-Copyright (c) 2007-2015 Soliant Consulting, Inc.
+Copyright (c) 2015 Soliant Consulting, Inc.
  
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,10 +1,118 @@
 Jira Issue Collector
 ====================
 
-```
-php ./vendor/bin/phpunit -c phpunit.xml.dist
-```
+[![Build Status](https://travis-ci.org/soliantconsulting/jira-issue-collector.svg?branch=master)](https://travis-ci.org/soliantconsulting/jira-issue-collector)
+[![Code Climate](https://codeclimate.com/github/soliantconsulting/jira-issue-collector/badges/gpa.svg)](https://codeclimate.com/github/soliantconsulting/jira-issue-collector)
+[![Test Coverage](https://codeclimate.com/github/soliantconsulting/jira-issue-collector/badges/coverage.svg)](https://codeclimate.com/github/soliantconsulting/jira-issue-collector/coverage)
+[![Latest Stable Version](https://poser.pugx.org/soliantconsulting/jira-issue-collector/v/stable)](https://packagist.org/packages/soliantconsulting/jira-issue-collector)
+[![Latest Unstable Version](https://poser.pugx.org/soliantconsulting/jira-issue-collector/v/unstable)](https://packagist.org/packages/soliantconsulting/jira-issue-collector)
+[![Total Downloads](https://poser.pugx.org/soliantconsulting/jira-issue-collector/downloads)](https://packagist.org/packages/soliantconsulting/jira-issue-collector)
+[![License](https://poser.pugx.org/soliantconsulting/jira-issue-collector/license)](https://packagist.org/packages/soliantconsulting/jira-issue-collector)
 
-```
-php ./vendor/bin/phpcs -p --standard=PSR2 src/ tests/ config/
-```
+
+Jira Issue Collector Module is a fast, convenient and free Zend Framework Module designed by
+[Soliant Consulting, Inc.][1] to dynamically add a Jira Issue Collector strictly through configuration.
+
+Jira Issue Collector Module is a lightweight package that enables the [Jira Issue Collector][2] to be injected into the
+`Zend\Mvc` response body when the standard `EVENT_FINISH` is triggered.
+
+Jira Issue Collector Module is [Composer][3] friendly, making it a snap to add to any existing Zend Framework MVC
+application.
+
+## Easy to Integrate
+
+* PSR-0 autoloading ([Composer][3] ready).
+* Install on an environment-specific basis using strictly standard `config/autoload/` settings.
+
+## System Requirements
+
+* PHP 5.5+
+* Zend Framework 2.5+
+
+With minimum effort, it should theoretically work older versions of PHP and Zend Framework 2, however, backward
+compatibility is not verified or maintained. If you needed to go back older than PHP 5.4, then use of short array syntax
+will definitely block you unless you refactor that.
+
+## License
+
+Jira Issue Collector Module is free for commercial and non-commercial use, licensed under the business-friendly
+standard MIT license.
+
+
+# Jira Issue Collector Module Documentation
+
+## Create Your Jira Issue Collector
+
+See the [Jira Issue Collector][2] documentation for basic setup. Once you have it configured, you will need to copy the
+url from the code snipped Jira creates for the Issue Collector. The wording in the Jira UI is subject to change, but you
+will be given two options something like this:
+
+* Embed in HTML
+* Embed in JavaScript
+
+In fact, they both use JavaScript, and it would be more explicit if they were labeled like this instead:
+
+* Do not use Jquery
+* Use Jquery
+
+Don't worry about the details of the configs until we get to the next section, but here are the bare-bones details you
+need to be aware of while setting up your Jira Issue Collector.
+
+On the assumption that Jquery may not be part of your project, the default and most basic configuration looks like this:
+
+    'soliant-jira-issue-collector' => [
+        'enabled'       => true,
+        'collector'     => [
+            'url'       => "https://jira.myserver.com/really-long-url",
+        ],
+    ],
+
+If you intend to use Jquery, and if you want to access the advanced options, you will need to enable Jquery support:
+
+    'soliant-jira-issue-collector' => [
+        'enabled'       => true,
+        'collector'     => [
+            'useJquery' => true,
+            'url'       => "https://jira.myserver.com/really-long-url",
+        ],
+    ],
+
+*NOTE: The url for every Issue Collector is unique and differs slightly between the two options, so be sure that if you
+change the setting in the Issue Collector, you also update it in your module config. You will need to copy the url out
+of the code snippet that Jira creates for you, as you won't need the rest of the code in your configuration.*
+
+## Basic Install
+
+The Jira Issue Collector Module installs like any standard Zend Framework module.
+
+### Composer
+
+Install the module via composer by adding it to your composer.json or by running
+
+    composer require soliantconsulting/jira-issue-collector:~1.0
+
+### Add Module Namespace
+
+Add the `Soliant\JiraIssueCollector` module to the module section of your `config/application.config.php`
+
+### Add Module Config
+
+Copy `config/soliant-jira-issue-collector.local.php.dist` from this module into your project
+   `config/autoload/soliant-jira-issue-collector.local.php`. Change any settings in it
+   according to your needs.
+
+## Advanced Options
+
+The comments in `config/soliant-jira-issue-collector.local.php.dist` provide details about the advanced settings the
+module provides. In short the module provides optional support for these features:
+
+* Custom css selector for that option in the Jira Issue Selector
+* Custom script template
+* Injection of a custom div tag template
+* Injection of a custom css style tag template
+
+[1]: http://www.soliantconsulting.com
+[2]: https://confluence.atlassian.com/adminjiracloud/using-the-issue-collector-776636529.html
+[3]: https://getcomposer.org/doc/00-intro.md
+[4]: http://www.php-fig.org/
+[5]: http://framework.zend.com/

--- a/composer.json
+++ b/composer.json
@@ -19,22 +19,22 @@
     ],
     "require": {
         "php":                               ">=5.5",
-        "zendframework/zend-mvc":            "2.*",
-        "zendframework/zend-eventmanager":   "2.*",
-        "zendframework/zend-stdlib":         "2.*",
-        "zendframework/zend-servicemanager": "2.*",
-        "zendframework/zend-modulemanager":  "2.*",
-        "zendframework/zend-version":        "2.*",
-        "zendframework/zend-view":           "2.*",
-        "zendframework/zend-http":           "2.*"
+        "zendframework/zend-mvc":            "^2",
+        "zendframework/zend-eventmanager":   "^2",
+        "zendframework/zend-stdlib":         "^2",
+        "zendframework/zend-servicemanager": "^2",
+        "zendframework/zend-modulemanager":  "^2",
+        "zendframework/zend-version":        "^2",
+        "zendframework/zend-view":           "^2",
+        "zendframework/zend-http":           "^2"
     },
     "require-dev": {
-        "zendframework/zend-debug":          "2.*",
-        "phpunit/phpunit":                   "~5",
-        "phpunit/phpunit-skeleton-generator": "*",
-        "mockery/mockery":                    "~0.9.4",
-        "squizlabs/php_codesniffer":          "2.*",
-        "codeclimate/php-test-reporter":      "~0.2.0"
+        "zendframework/zend-debug":          "^2.5",
+        "phpunit/phpunit":                   "^4",
+        "phpunit/phpunit-skeleton-generator": "^2",
+        "mockery/mockery":                    "^0.9",
+        "squizlabs/php_codesniffer":          "^2",
+        "codeclimate/php-test-reporter":      "^0.2"
     },
     "suggest": {
     },

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "soliantconsulting/jira-issue-collector",
-    "description": "Module for injecting Jira issue collector into layout.",
+    "description": "A Zend Framework Module for injecting a Jira issue collector into the Zend\\Mvc response body.",
     "type": "zf-module",
     "license": "MIT",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "soliantconsulting-jira-issue-collector",
+    "version": "1.0.0",
+    "description": "soliantconsulting-jira-issue-collector is a ZF2 module that injects an issue collector via config.",
+    "main": "Gruntfile.js",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/soliantconsulting/jira-issue-collector.git"
+    },
+    "keywords": [
+        "Jira", "Issue Collector"
+    ],
+    "author": "Jeremiah Small",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/soliantconsulting/jira-issue-collector/issues"
+    },
+    "devDependencies": {
+        "grunt": "~0.4",
+        "grunt-phpcs": "*",
+        "grunt-phplint": "*",
+        "grunt-phpunit": "*",
+        "grunt-mkdir": "*"
+    }
+}

--- a/src/Soliant/JiraIssueCollector/Factory/OptionsFactory.php
+++ b/src/Soliant/JiraIssueCollector/Factory/OptionsFactory.php
@@ -10,7 +10,6 @@
 namespace Soliant\JiraIssueCollector\Factory;
 
 use Soliant\JiraIssueCollector\Options;
-use Zend\Debug\Debug;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 

--- a/src/Soliant/JiraIssueCollector/Listener.php
+++ b/src/Soliant/JiraIssueCollector/Listener.php
@@ -9,7 +9,6 @@
 
 namespace Soliant\JiraIssueCollector;
 
-use Zend\Debug\Debug;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
 use Zend\Mvc\MvcEvent;

--- a/src/Soliant/JiraIssueCollector/Module.php
+++ b/src/Soliant/JiraIssueCollector/Module.php
@@ -9,7 +9,6 @@
 
 namespace Soliant\JiraIssueCollector;
 
-use Zend\Debug\Debug;
 use Zend\EventManager\EventInterface;
 use Zend\EventManager\ListenerAggregateInterface;
 use Zend\ModuleManager\Feature\BootstrapListenerInterface;


### PR DESCRIPTION
- Downgrade PhpUnit to `~4` to maintain PHP 5.5 compatibility.
- Update `composer.json` to recommended caret constraint for library code. See https://getcomposer.org/doc/articles/versions.md#caret
- Add grunt support for running tests
- Add `README.md` and `CONTRIBUTING.md`
- Revise copyright date
- Optimize imports
